### PR TITLE
feat: add pre-commit hook for Spotless code formatting

### DIFF
--- a/docs/git-hook-installation.md
+++ b/docs/git-hook-installation.md
@@ -1,0 +1,40 @@
+# Spotless Pre-Commit Hook
+
+This repository uses a pre-commit hook for spotless. It provides a script that installs a Git pre-commit hook that 
+automatically runs the Spotless code formatter on all Java files before a commit enters the repository. This ensures 
+that your code stays clean and consistent without manual formatting.
+
+## 📜 Features
+
+* Automatically formats Java code on every commit.
+* Stages formatted changes automatically (git add .).
+* Prevents unformatted code from entering the repository.
+* Easy to install without manual configuration.
+
+## ⚡ Installation
+
+Run the installation script:
+
+```
+./install-precommit-hook.sh
+```
+
+### Note:
+
+Make sure the script is located at the root of your project.
+
+This script creates the hook at `.git/hooks/pre-commit` and makes it executable.
+
+## 🏰 Usage
+
+* Make changes to your code.
+* Run git commit.
+* Spotless will automatically format the code and stage any changes.
+* The commit completes once all changes are cleanly formatted.
+
+
+## ✅ Notes
+
+* Ensure that Gradle and Spotless are set up in your project.
+* The hook works locally; changes still need to be pushed to GitHub.
+* The hook automatically stages formatted changes, so commit or stash uncommitted changes beforehand if needed.

--- a/git-hook-install.sh
+++ b/git-hook-install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+HOOK_FILE=".git/hooks/pre-commit"
+
+# Create Pre-Commit Hook for Spotless
+cat > "$HOOK_FILE" <<'EOF'
+#!/bin/bash
+# Spotless Apply vor jedem Commit
+./gradlew spotlessApply
+git add .
+EOF
+
+# Make the hook executable
+chmod +x "$HOOK_FILE"
+
+echo " ✅ Pre-commit Hook for Spotless has been installed successfully."

--- a/src/main/java/com/adventofcode/year2025/application/usecases/SolveDay02RiddleUseCase.java
+++ b/src/main/java/com/adventofcode/year2025/application/usecases/SolveDay02RiddleUseCase.java
@@ -6,7 +6,6 @@ import com.adventofcode.year2025.domain.ProductRanges;
 import com.adventofcode.year2025.domain.RiddleUseCase;
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.LongStream;


### PR DESCRIPTION
Implement a script to install a Git pre-commit hook that automatically formats Java code using Spotless before commits. This ensures consistent code quality and reduces manual formatting efforts.